### PR TITLE
Fix false positive on Mac M1

### DIFF
--- a/Sources/DTTJailbreakDetection/DTTJailbreakDetection.m
+++ b/Sources/DTTJailbreakDetection/DTTJailbreakDetection.m
@@ -28,6 +28,12 @@
 {
 #if !(TARGET_IPHONE_SIMULATOR)
 
+    if (@available(iOS 14.0, *)) {
+        if ([NSProcessInfo processInfo].isiOSAppOnMac)
+        {
+            return NO;
+        }
+    }
     FILE *file = fopen("/Applications/Cydia.app", "r");
     if (file) {
         fclose(file);


### PR DESCRIPTION
fixes #12 
As @skuske suggested this will return NO when is running on MAC m1, it will check if isiOSAppOnMac when iOS is 14.0 or greater only, because iOS 14 was first version on Mac